### PR TITLE
fix: pin trivy-action to safe version (security incident response) [SEC-501]

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -150,7 +150,7 @@ jobs:
           docker load --input ${{ env.REPO_NAME }}/${{ env.REPO_NAME }}${{ github.sha }}.tar
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
         with:
           image-ref: '${{ env.REPO_NAME }}'
           hide-progress: false


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] I have confirmed that the PR type is appropriate for the change I am making.
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

* Pin `aquasecurity/trivy-action` to safe version `v0.35.0` (SHA: `57a97c7e7821a5776cebc9bb87c984fa69cba8f1`) per the security advisory: https://github.com/aquasecurity/trivy/discussions/10425
* Ref: SEC-501