### PR TITLE
ci: Replace the archived SonarCloud scan action [DEVOP-8628]

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,7 +50,7 @@ jobs:
         run: make test_and_cover
 
       - name: sonarcloud-scan
-        uses: sonarsource/sonarcloud-github-action@master
+        uses: sonarsource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

SonarSource archived the sonarcloud-github-action repository. We move
the scan step to the successor action, sonarqube-scan-action, pinned
to the v8.2.1 commit hash - the same pin our shared workflow templates
now use. For SonarQube Cloud the action needs only SONAR_TOKEN, so
nothing else changes.

Refs: #DEVOP-8628

Signed-off-by: Christian Witts <christian@honestbank.com>
